### PR TITLE
Fix error messages

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -342,8 +342,8 @@ command_line::add_arg(desc_cmd_sett, arg_print_genesis_tx);
         std::cout << "Configuration error: Cannot open configuration file" << std::endl;
         std::cout << "" << std::endl;
         std::cout << "Usage:" << std::endl;
-        std::cout << "Windows:   croatd.exe --config-file configs/dashcoin.conf" << std::endl;
-        std::cout << "Linux/Mac:   ./croatd --config-file configs/dashcoin.conf" << std::endl;
+        std::cout << "Windows:   croatd.exe --config-file configs/croat.conf" << std::endl;
+        std::cout << "Linux/Mac:   ./croatd --config-file configs/croat.conf" << std::endl;
         return false;
       }
       po::notify(vm);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1309,8 +1309,8 @@ int main(int argc, char* argv[]) {
       std::cout << "Configuration error: Cannot open configuration file" << std::endl;
       std::cout << "" << std::endl;
       std::cout << "Usage:" << std::endl;
-      std::cout << "Windows:   simplewallet.exe --config-file configs/dashcoin.conf" << std::endl;
-      std::cout << "Linux/Mac:   ./simplewallet --config-file configs/dashcoin.conf" << std::endl;
+      std::cout << "Windows:   simplewallet.exe --config-file configs/croat.conf" << std::endl;
+      std::cout << "Linux/Mac:   ./simplewallet --config-file configs/croat.conf" << std::endl;
       return false;
     }
     po::notify(vm);


### PR DESCRIPTION
The error messages in the daemon and wallet programs that appear when no config file has been specified refer to the file `dashcoin.conf`, yet after this project was forked from cryptonote-generator and modified that file was replaced by `croat.conf`. This PR modifies the error messages so they refer to the correct file.